### PR TITLE
Update 1.13.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,8 @@ source:
 build:
   number: 0
   noarch: python
+  # anyio >=3.1.0,<4 and websocket-client currentrly aren't available on s390x.
+  skip: True  # [s390x]
   script:
     - {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
   entry_points:
@@ -52,7 +54,8 @@ test:
   imports:
     - jupyter_server
   downstreams:
-    - jupyterlab >=3.2
+  # nodejs >=14,<15 currently isn't available on osx-arm64
+    - jupyterlab >=3.2  # [not (osx and arm64)]
 
 about:
   home: https://jupyter.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,6 @@ build:
   number: 0
   noarch: python
   # anyio >=3.1.0,<4 and websocket-client currentrly aren't available on s390x.
-  skip: True  # [s390x]
   script:
     - {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
   entry_points:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "jupyter_server" %}
-{% set version = "1.4.1" %}
+{% set version = "1.13.5" %}
 
 package:
   name: {{ name }}
@@ -7,10 +7,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: b0126f237f679533eec46244cfc66d61e3a1f8ec0fad2d47352fa19d3e754e47
+  sha256: 9e3e9717eea3bffab8cfb2ff330011be6c8bbd9cdae5b71cef169fcece2f19d3
 
 build:
   number: 0
+  noarch: python
   script:
     - {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
   entry_points:
@@ -19,25 +20,26 @@ build:
 requirements:
   host:
     - python
+    - jupyter-packaging >=0.9,<1
     - pip
   run:
-    - python
+    - python >=3.7
+    - anyio >=3.1.0,<4
+    - argon2-cffi
     - ipython_genutils
     - jinja2
-    - jupyter_core >=4.4.0
     - jupyter_client >=6.1.1
+    - jupyter_core >=4.6.0
     - nbconvert
     - nbformat
+    - packaging
+    - prometheus_client
     - pyzmq >=17
     - send2trash
     - terminado >=0.8.3
-    - tornado >=6.1
-    - traitlets >=4.2.1
-    - prometheus_client
-    - pywin32 >=1.0  # [win]
-    - anyio >=2.0.2
-    # TODO: remove after anyio 2.1.0 available on all supported platforms 
-    - dataclasses  # [py<37]
+    - tornado >=6.1.0
+    - traitlets >=5
+    - websocket-client
 
 test:
   requires:
@@ -47,6 +49,8 @@ test:
     - jupyter server -h
   imports:
     - jupyter_server
+  downstreams:
+    - jupyterlab >=3.2
 
 about:
   home: https://jupyter.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,8 @@ requirements:
     - python
     - jupyter-packaging >=0.9,<1
     - pip
+    - setuptools
+    - wheel
   run:
     - python >=3.7
     - anyio >=3.1.0,<4


### PR DESCRIPTION
Bug Tracker: new open issues https://github.com/jupyter/jupyter_server/issues
Github releases:  https://github.com/jupyter/jupyter_server/releases
Upstream Changelog: https://github.com/jupyter/jupyter_server/blob/main/CHANGELOG.md
License: https://github.com/jupyter-server/jupyter_server/blob/v1.13.5/COPYING.md
Upstream pyproject.toml: https://github.com/jupyter-server/jupyter_server/blob/v1.13.5/pyproject.toml
Upstream setup.cfg: https://github.com/jupyter-server/jupyter_server/blob/v1.13.5/setup.cfg

The package jupyter_server is mentioned inside the packages:
jupyterlab | jupyterlab_server | nbclassic | terminado |

Actions:
1. Use `noarch: python`
2. Update host dependencies: add `jupyter-packaging >=0.9,<1`, `setuptools`, `wheel`
3. Update run dependencies
4. Add  `downstreams` for additional testing: `jupyterlab >=3.2  # [not (osx and arm64)]`
