### PR TITLE
jupyter_server 1.23.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,11 +52,11 @@ test:
     - jupyter server -h
   imports:
     - jupyter_server
-  #downstreams:
+  downstreams:
     # nodejs >=14,<15 currently isn't available on osx-arm64
     # Skip win because of a false positive pip check fail: jupyter-server 1.13.5 has requirement pywinpty<2
-    #- jupyterlab >=3.2  # [not ((osx and arm64) or win or s390x)]
-    #- jupyterlab_server >=2.14.0  # [not (linux and s390x)]
+    - jupyterlab >=3.2  # [not ((osx and arm64) or win or s390x)]
+    - jupyterlab_server >=2.14.0  # [not (linux and s390x)]
 
 about:
   home: https://jupyter.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - wheel
   run:
     - python
-    - anyio >=3.1.0
+    - anyio >=3.1.0,<4
     - argon2-cffi
     - jinja2
     - jupyter_client >=6.1.12

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,11 +52,11 @@ test:
     - jupyter server -h
   imports:
     - jupyter_server
-  downstreams:
+  #downstreams:
     # nodejs >=14,<15 currently isn't available on osx-arm64
     # Skip win because of a false positive pip check fail: jupyter-server 1.13.5 has requirement pywinpty<2
-    - jupyterlab >=3.2  # [not ((osx and arm64) or win or s390x)]
-    - jupyterlab_server >=2.14.0  # [not (linux and s390x)]
+    #- jupyterlab >=3.2  # [not ((osx and arm64) or win or s390x)]
+    #- jupyterlab_server >=2.14.0  # [not (linux and s390x)]
 
 about:
   home: https://jupyter.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "jupyter_server" %}
-{% set version = "1.18.1" %}
+{% set version = "1.23.4" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 2b72fc595bccae292260aad8157a0ead8da2c703ec6ae1bb7b36dbad0e267ea7
+  sha256: 4ee4f311bd944bcf8060a8b746059571c40f6b8ada1d1e6e51239d26ab23b15c
 
 build:
   number: 0
@@ -27,7 +27,7 @@ requirements:
     - wheel
   run:
     - python
-    - anyio >=3.1.0,<4
+    - anyio >=3.1.0
     - argon2-cffi
     - jinja2
     - jupyter_client >=6.1.12
@@ -56,7 +56,7 @@ test:
     # nodejs >=14,<15 currently isn't available on osx-arm64
     # Skip win because of a false positive pip check fail: jupyter-server 1.13.5 has requirement pywinpty<2
     #- jupyterlab >=3.2  # [not ((osx and arm64) or win or s390x)]
-    #- jupyterlab_server >=2.10  # [linux and s390x]
+    #- jupyterlab_server >=2.14.0  # [not (linux and s390x)]
 
 about:
   home: https://jupyter.org


### PR DESCRIPTION
**Jira ticket:** [PKG-933](https://anaconda.atlassian.net/browse/PKG-933) (jupyter_server 1.23.4)

**The upstream data:**
Github releases:  https://github.com/jupyter/jupyter_server/releases
[Diff between the latest and previous upstream releases](https://github.com/jupyter/jupyter_server/compare/1.18.1...1.23.4)
Changelog: https://github.com/jupyter/jupyter_server/blob/main/CHANGELOG.md

**_Actions:_**

- Update pinning for anyio

- Enable downstreams for testing

**_Notes:_**
 * Update **not** to the latest **v2.0.2** but to **1.23.4** (the branch `1.x`) because of breaking changes in >=2.0.0. See also https://github.com/conda-forge/jupyter_server-feedstock/pull/110#issue-1505617476
 * And `jupyterlab_server` requires  `jupyter_server >=1.21` but we have `1.18.1`.
 * Tested with downstream packages:
```
    - jupyterlab >=3.2  # [not ((osx and arm64) or win or s390x)]
    - jupyterlab_server >=2.14.0  # [not (linux and s390x)]
```

**Additional info:**

<details>

**Package's statistics**

<details>

 * Priority  | effort:  | Category:  | subcategory:  | pkg_type: 
 * Outdated platfroms: 
 * Latest version: 
 * Release on PyPi:
    * version: 2.0.2
    * date: 2022-12-20T16:07:01
* [PyPi history](https://pypi.org/project/jupyter_server/#history)
 * Popularity: 
    * 3 months downloads: 
    * All time:  3166027 downloads -  jupyter_server  2.0.2  The backend—i.e. core services, APIs, and REST endpoints to Jupyter web applications.  

</details>

**Other checks:**

<details>

1. - [ ] The upstream url error:
    https://github.com/jupyter/jupyter_server/tree/v
    301
2. - [ ] The upstream url error:
    https://jupyter.org
    
3. - [ ] Check the pinnings
4. - [ ] Changelog url error:
    https://github.com/jupyter/jupyter_server/tree/v
    301
5. - [ ] Additional research
    https://github.com/jupyter/jupyter_server/issues
    
6. - [ ] `dev_url` error:
    https://github.com/jupyter/jupyter_server
    
7. - [ ] `doc_url` error:
    https://jupyter-server.readthedocs.io
    
8. - [ ] Verify that the `build_number` is correct
9. - [ ] Verify if the package needs `setuptools`
    To
setuptools
10. - [x] has `wheel`
11. - [ ] NO `pip` in test
    pip
Skip
12. - [ ] Verify the test section
13. - [ ] Verify if the package is `architecture specific`
14. - [ ] Verify that private modules are not mentioned in the recipe For example: (_private_module)
15.  - [x] license_file: COPYING.md is present

16. - [x] license_family BSD is present
17. - [x] License: BSD-3-Clause
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier                           |
|:-------------------------------------|
| BSD-3-Clause                         |
| BSD-3-Clause-Attribution             |
| BSD-3-Clause-Clear                   |
| BSD-3-Clause-LBNL                    |
| BSD-3-Clause-Modification            |
| BSD-3-Clause-No-Military-License     |
| BSD-3-Clause-No-Nuclear-License      |
| BSD-3-Clause-No-Nuclear-License-2014 |
| BSD-3-Clause-No-Nuclear-Warranty     |
| BSD-3-Clause-Open-MPI                |
</details>

**Check GUI app:**

<details>
**GUI app check**

Recommend to make testing in c3i_test2 channel!
../aggregate/jupyter_server is a GUI aplication

**End GUI check**

</details>

**Check dependency issues:**

<details>
../aggregate/jupyter_server-feedstock/recipe/meta.yaml
Dependencies: ['websocket-client', 'setuptools', 'jupyter_core >=4.7.0', 'traitlets >=5.1', 'jupyter_client >=6.1.12', 'tornado >=6.1.0', 'jupyter-packaging >=0.12.0,<1', 'terminado >=0.8.3', 'nbconvert >=6.4.4', 'prometheus_client', 'nbformat >=5.2.0', 'packaging', 'anyio >=3.1.0,<4', 'python', 'argon2-cffi', 'wheel', 'jinja2', 'pyzmq >=17', 'send2trash', 'pip']


noarch:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-ppc64le:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-s390x:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-arm64:
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

win-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

</details>

**Package Build Score: 18**


</details>